### PR TITLE
Check for enterprise license on startup

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -41,6 +41,14 @@ type Plugin struct {
 
 // OnActivate is invoked when the plugin is activated. If an error is returned, the plugin will be deactivated.
 func (p *Plugin) OnActivate() error {
+	// Check for an enterprise license or a development environment
+	mmConfig := p.API.GetConfig()
+	license := p.API.GetLicense()
+
+	if !pluginapi.IsEnterpriseLicensedOrDevelopment(mmConfig, license) {
+		return errors.New("this plugin requires an Enterprise license")
+	}
+
 	p.client = pluginapi.NewClient(p.API, p.Driver)
 
 	config := p.getConfiguration()


### PR DESCRIPTION
### Summary
We need to check for an enterprise license on startup. It's a better user experience than finding out when the pluginapis don't work.

### Test cases
1. Deploy the plugin normally with an enterprise license applied.

Expected Result: The plugin starts up as normal and works

1. Remove the license on http://localhost:8065/admin_console/about/license
3. Go to http://localhost:8065/admin_console/plugins/plugin_management
4. Disable the plugin

Expected Result: The plugin fails to start with an error saying:`this plugin requires an Enterprise license`

