### PR TITLE
Properly page keycloak groups

### DIFF
--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -545,9 +545,13 @@ func (k *KeycloakClient) SyncGroupMap(ctx context.Context) error {
 	perPage := 100
 
 	for {
+		first := page
+		if first != 0 {
+			first = (page * perPage)
+		}
 		// Get groups page by page
 		params := gocloak.GetGroupsParams{
-			First: &page,
+			First: &first,
 			Max:   &perPage,
 		}
 		result, err := k.executeWithRetry(ctx, func(t string) (interface{}, error) {


### PR DESCRIPTION
#### Summary
The groups paging was incorrect. It uses first instead of page so it requires multiplying page by perPage. The old way would still work but it would have been terribly inefficient. It would only have gotten one new group at a time after the first 100

