### PR TITLE
Fix bug with non group constrained memberships on teams

### DIFF
--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -305,6 +305,8 @@ func (k *KeycloakClient) removeUserFromTeams(groupID string, user *mmModel.User)
 				"error", err)
 			continue
 		}
+		// Don't remove user from the team if it's not group constrained.
+		// Groups get associated with teams when a group is associated to a channel within the team. So we cannot tell if the user was added to the team directly or through the group.
 		if team.GroupConstrained != nil && *team.GroupConstrained {
 			if err = k.PluginAPI.Team.DeleteMember(teamSyncable.SyncableId, user.Id, ""); err != nil {
 				k.PluginAPI.Log.Error("Failed to remove user from team",

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -298,11 +298,20 @@ func (k *KeycloakClient) removeUserFromTeams(groupID string, user *mmModel.User)
 	}
 
 	for _, teamSyncable := range teamSyncables {
-		if err = k.PluginAPI.Team.DeleteMember(teamSyncable.SyncableId, user.Id, ""); err != nil {
-			k.PluginAPI.Log.Error("Failed to remove user from team",
-				"user_id", user.Id,
+		team, err := k.PluginAPI.Team.Get(teamSyncable.SyncableId)
+		if err != nil {
+			k.PluginAPI.Log.Error("Failed to get team",
 				"team_id", teamSyncable.SyncableId,
 				"error", err)
+			continue
+		}
+		if team.GroupConstrained != nil && *team.GroupConstrained {
+			if err = k.PluginAPI.Team.DeleteMember(teamSyncable.SyncableId, user.Id, ""); err != nil {
+				k.PluginAPI.Log.Error("Failed to remove user from team",
+					"user_id", user.Id,
+					"team_id", teamSyncable.SyncableId,
+					"error", err)
+			}
 		}
 	}
 }
@@ -521,8 +530,8 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 
 	if len(removedFromGroups) > 0 {
 		for _, groupID := range removedFromGroups {
-			k.removeUserFromTeams(groupID, user)
 			k.removeUserFromChannels(groupID, user)
+			k.removeUserFromTeams(groupID, user)
 		}
 	}
 


### PR DESCRIPTION
### Summary
Don't remove users from the team if it's not group constrained.

Groups get associated with teams when a group is associated to a channel within the team. We cannot tell if the user was added to the team directly or through the group. It's safe to assume that the user can remain in the team if it's not group constrained and they are removed from the group associated to the group synced channel.

Before this fix there are situations where you have a team that you are a member of and you are part of 10 channels. The admin decides to create a group sync channel within that team, so now that group is synced to the channel and the team. On the next login you have been removed from that group so now you are also removed from that team. My fix will keep you in that team but remove you from the group synced channel

### Tests
#### Verify syncs working
1. Set up Keycloak group
    • In Keycloak, create a group called "TestGroup"
    • Add your test user to this group
2. Link the Keycloak group in Mattermost
    • In Mattermost System Console > User Management > Groups
    • Link the "TestGroup" from Keycloak
3. Create a regular team in Mattermost
    • Create a new team called "Regular Team"
    • Ensure "Group Sync" is **NOT** enabled for this team (team is not group-constrained)
4. Create a group-constrained team in Mattermost
    • Create another team called "Group-Constrained Team"
    • Go to System Console > User Management > Teams
    • Find "Group-Constrained Team" and enable "Sync Group Members"
    • Select "TestGroup" as the group
5. Create channels and set up group sync
    • In "Regular Team", create a channel called "Group-Synced Channel"
    • In "Group-Constrained Team", create a channel called "Group Channel"
    • For both channels:
       • Go to System Console > User Management > Channels
       • Find each channel and add "TestGroup" to it
       • Enable "Sync Group Members" for both channels
6. Verify initial state
    • Have the test user log in via SAML
    • Verify they are added to:
       • "Regular Team"
       • "Group-Constrained Team"
       • "Group-Synced Channel" in Regular Team
       • "Group Channel" in Group-Constrained Team

#### Verify fix works
 1 Remove user from Keycloak group
    • In Keycloak admin console, remove the test user from "TestGroup"
 2 Trigger SAML login
    • Have the test user log out and log back in via SAML
    • This will trigger the group synchronization process
 3 Verify the results
    • The user should:
       • STILL be a member of "Regular Team" (this is the fix)
       • NO LONGER be a member of "Group-Constrained Team"
       • NO LONGER be a member of "Group-Synced Channel" in Regular Team
       • NO LONGER be a member of "Group Channel" in Group-Constrained Team

#### Verify they can be added back
 1 Re-add user to group
    • Add the test user back to "TestGroup" in Keycloak
    • Have them log in again
    • Verify they are added back to all teams and channels

