### PR TITLE
Improve efficiency of some calls while handling channel/team memberships and prep for new config

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -80,6 +80,13 @@
                 "type": "text",
                 "help_text": "The SAML assertion attribute that contains the user's groups.",
                 "placeholder": "Enter the groups attribute name"
+            },
+            {
+                "key": "FailLoginOnGroupSyncError",
+                "display_name": "Fail Login on Group Sync Error",
+                "type": "bool",
+                "help_text": "Users will fail to sign in if there is a failure to remove them from a group, channel or team.",
+                "default": false
             }
         ]
     }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,23 +7,25 @@ import (
 // Configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration.
 type Configuration struct {
-	GroupsProvider          string `json:"groupsprovider"`
-	KeycloakRealm           string `json:"keycloakrealm"`
-	KeycloakClientID        string `json:"keycloakclientid"`
-	KeycloakClientSecret    string `json:"keycloakclientsecret"`
-	KeycloakHost            string `json:"keycloakhost"`
-	KeycloakGroupsAttribute string `json:"keycloakgroupsattribute"`
-	EncryptionKey           string `json:"encryptionkey"`
+	GroupsProvider            string `json:"groupsprovider"`
+	KeycloakRealm             string `json:"keycloakrealm"`
+	KeycloakClientID          string `json:"keycloakclientid"`
+	KeycloakClientSecret      string `json:"keycloakclientsecret"`
+	KeycloakHost              string `json:"keycloakhost"`
+	KeycloakGroupsAttribute   string `json:"keycloakgroupsattribute"`
+	EncryptionKey             string `json:"encryptionkey"`
+	FailLoginOnGroupSyncError bool   `json:"failloginongroupsyncerror"`
 }
 
 // KeycloakConfig contains all Keycloak-specific configuration
 type KeycloakConfig struct {
-	Host            string
-	Realm           string
-	ClientID        string
-	ClientSecret    string
-	GroupsAttribute string
-	EncryptionKey   string
+	Host                      string
+	Realm                     string
+	ClientID                  string
+	ClientSecret              string
+	GroupsAttribute           string
+	EncryptionKey             string
+	FailLoginOnGroupSyncError bool
 }
 
 // ToMap converts the configuration to a map
@@ -44,12 +46,13 @@ func (c *Configuration) ToMap() (map[string]interface{}, error) {
 // GetKeycloakConfig returns all Keycloak-related configuration as a single struct
 func (c *Configuration) GetKeycloakConfig() KeycloakConfig {
 	return KeycloakConfig{
-		Host:            c.KeycloakHost,
-		Realm:           c.KeycloakRealm,
-		ClientID:        c.KeycloakClientID,
-		ClientSecret:    c.KeycloakClientSecret,
-		GroupsAttribute: c.KeycloakGroupsAttribute,
-		EncryptionKey:   c.EncryptionKey,
+		Host:                      c.KeycloakHost,
+		Realm:                     c.KeycloakRealm,
+		ClientID:                  c.KeycloakClientID,
+		ClientSecret:              c.KeycloakClientSecret,
+		GroupsAttribute:           c.KeycloakGroupsAttribute,
+		EncryptionKey:             c.EncryptionKey,
+		FailLoginOnGroupSyncError: c.FailLoginOnGroupSyncError,
 	}
 }
 
@@ -61,13 +64,14 @@ func (c *Configuration) GetGroupsProvider() string {
 // Clone creates a deep copy of the configuration.
 func (c *Configuration) Clone() *Configuration {
 	var clone = &Configuration{
-		GroupsProvider:          c.GroupsProvider,
-		KeycloakRealm:           c.KeycloakRealm,
-		KeycloakClientID:        c.KeycloakClientID,
-		KeycloakClientSecret:    c.KeycloakClientSecret,
-		KeycloakHost:            c.KeycloakHost,
-		KeycloakGroupsAttribute: c.KeycloakGroupsAttribute,
-		EncryptionKey:           c.EncryptionKey,
+		GroupsProvider:            c.GroupsProvider,
+		KeycloakRealm:             c.KeycloakRealm,
+		KeycloakClientID:          c.KeycloakClientID,
+		KeycloakClientSecret:      c.KeycloakClientSecret,
+		KeycloakHost:              c.KeycloakHost,
+		KeycloakGroupsAttribute:   c.KeycloakGroupsAttribute,
+		EncryptionKey:             c.EncryptionKey,
+		FailLoginOnGroupSyncError: c.FailLoginOnGroupSyncError,
 	}
 	return clone
 }

--- a/server/groups/client.go
+++ b/server/groups/client.go
@@ -49,6 +49,7 @@ func NewClient(provider string, cfg *config.Configuration, kvstore kvstore.KVSto
 			keycloakConfig.ClientID,
 			keycloakConfig.ClientSecret,
 			keycloakConfig.EncryptionKey,
+			keycloakConfig.FailLoginOnGroupSyncError,
 			kvstore,
 			client,
 		), nil

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -586,7 +586,7 @@ func (k *KeycloakClient) removeUserFromTeams(teamsToLeave map[string]bool, user 
 		// Check if they are a member of the team
 		member, err := k.PluginAPI.Team.GetMember(teamID, user.Id)
 		if err != nil {
-			if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if strings.ToLower(err.Error()) == "not found" {
 				k.PluginAPI.Log.Debug("User has already left the team", "team_id", teamID, "user_id", user.Id)
 			} else {
 				k.PluginAPI.Log.Error("Failed to get team member",
@@ -597,6 +597,7 @@ func (k *KeycloakClient) removeUserFromTeams(teamsToLeave map[string]bool, user 
 			continue
 		}
 		if member != nil && member.DeleteAt == 0 {
+			k.PluginAPI.Log.Debug("Removing user from team", "team_id", teamID, "user_id", user.Id)
 			if err = k.PluginAPI.Team.DeleteMember(teamID, user.Id, ""); err != nil {
 				k.PluginAPI.Log.Error("Failed to remove user from team",
 					"user_id", user.Id,
@@ -614,7 +615,7 @@ func (k *KeycloakClient) addUserToTeams(teamsToJoin map[string]bool, user *mmMod
 		// Check if they are a member of the team
 		member, err := k.PluginAPI.Team.GetMember(teamID, user.Id)
 		if err != nil {
-			if !strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if strings.ToLower(err.Error()) != "not found" {
 				k.PluginAPI.Log.Error("Failed to get team member",
 					"user_id", user.Id,
 					"team_id", teamID,
@@ -624,6 +625,7 @@ func (k *KeycloakClient) addUserToTeams(teamsToJoin map[string]bool, user *mmMod
 		}
 
 		if member == nil || (member.DeleteAt != 0) {
+			k.PluginAPI.Log.Debug("Adding user to team", "team_id", teamID, "user_id", user.Id)
 			if _, err = k.PluginAPI.Team.CreateMember(teamID, user.Id); err != nil {
 				k.PluginAPI.Log.Error("Failed to add user to team",
 					"user_id", user.Id,
@@ -640,7 +642,7 @@ func (k *KeycloakClient) removeUserFromChannels(channelsToLeave map[string]bool,
 		_, err := k.PluginAPI.Channel.GetMember(channelID, user.Id)
 		if err != nil {
 			// check if the error is because the user was not found
-			if strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if strings.ToLower(err.Error()) == "not found" {
 				k.PluginAPI.Log.Debug("User has already left the channel", "channel_id", channelID, "user_id", user.Id)
 			} else {
 				k.PluginAPI.Log.Error("Failed to get channel member",
@@ -650,6 +652,7 @@ func (k *KeycloakClient) removeUserFromChannels(channelsToLeave map[string]bool,
 			}
 			continue
 		}
+		k.PluginAPI.Log.Debug("Removing user from channel", "channel_id", channelID, "user_id", user.Id)
 		if err = k.PluginAPI.Channel.DeleteMember(channelID, user.Id); err != nil {
 			k.PluginAPI.Log.Error("Failed to remove user from channel",
 				"user_id", user.Id,
@@ -666,7 +669,7 @@ func (k *KeycloakClient) addUserToChannels(channelsToJoin map[string]bool, user 
 		member, err := k.PluginAPI.Channel.GetMember(channelID, user.Id)
 		if err != nil {
 			// check if the error is because the user was not found
-			if !strings.Contains(strings.ToLower(err.Error()), "not found") {
+			if strings.ToLower(err.Error()) != "not found" {
 				k.PluginAPI.Log.Error("Failed to get channel member",
 					"user_id", user.Id,
 					"channel_id", channelID,
@@ -676,6 +679,7 @@ func (k *KeycloakClient) addUserToChannels(channelsToJoin map[string]bool, user 
 		}
 
 		if member == nil {
+			k.PluginAPI.Log.Debug("Adding user to channel", "channel_id", channelID, "user_id", user.Id)
 			if _, err = k.PluginAPI.Channel.AddMember(channelID, user.Id); err != nil {
 				k.PluginAPI.Log.Error("Failed to add user to channel",
 					"user_id", user.Id,

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -544,7 +544,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 	}
 
 	finalTeamsToLeave := make(map[string]bool)
-	// Loop over teams for removal and check if it's in the list of teams to add.
+	// Loop over teams to leave and check if it's in the list of teams to join.
 	// If it's in the teams to join, we don't need to remove the team membership.
 	for teamID := range proposedTeamsToLeave {
 		if _, exists := finalTeamsToJoin[teamID]; !exists {
@@ -553,7 +553,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 	}
 
 	finalChannelsToLeave := make(map[string]bool)
-	// Loop over teams for removal and check if it's in the list of teams to add
+	// Loop over channels to leave and check if it's in the list of channels to join.
 	// If it's in the channels to join, we don't need to remove the team membership.
 	for channelID := range proposedChannelsToLeave {
 		if _, exists := finalChannelsToJoin[channelID]; !exists {

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -443,7 +443,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 						"error", err)
 				}
 				if err := k.getSyncableChannelsForRemoval(group.Id, channelsToLeave); err != nil {
-					k.PluginAPI.Log.Error("Failed to get teams for removal",
+					k.PluginAPI.Log.Error("Failed to get channels for removal",
 						"group_id", group.Id,
 						"error", err)
 				}
@@ -623,7 +623,7 @@ func (k *KeycloakClient) addUserToTeams(teamsToJoin map[string]bool, user *mmMod
 			}
 		}
 
-		if member == nil || (member != nil && member.DeleteAt != 0) {
+		if member == nil || (member.DeleteAt != 0) {
 			if _, err = k.PluginAPI.Team.CreateMember(teamID, user.Id); err != nil {
 				k.PluginAPI.Log.Error("Failed to add user to team",
 					"user_id", user.Id,

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -367,7 +367,7 @@ func (k *KeycloakClient) getSyncableTeamsForRemoval(groupID string, teamsToRemov
 	return nil
 }
 
-// getSyncableTeamsForAddition adds team IDs that the user should be added to into the provided map
+// getSyncableChannelsForAddition adds channel IDs that the user should be added to into the provided map
 func (k *KeycloakClient) getSyncableChannelsForAddition(groupID string, channelsToAdd map[string]bool) error {
 	channelSyncables, err := k.PluginAPI.Group.GetSyncables(groupID, mmModel.GroupSyncableTypeChannel)
 	if err != nil {
@@ -383,7 +383,7 @@ func (k *KeycloakClient) getSyncableChannelsForAddition(groupID string, channels
 	return nil
 }
 
-// getSyncableTeamsForRemoval adds team IDs that the user should be removed from into the provided map
+// getSyncableChannelsForRemoval adds channel IDs that the user should be removed from into the provided map
 func (k *KeycloakClient) getSyncableChannelsForRemoval(groupID string, channelsToRemove map[string]bool) error {
 	channelSyncables, err := k.PluginAPI.Group.GetSyncables(groupID, mmModel.GroupSyncableTypeChannel)
 	if err != nil {
@@ -554,7 +554,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 
 	finalChannelsToLeave := make(map[string]bool)
 	// Loop over channels to leave and check if it's in the list of channels to join.
-	// If it's in the channels to join, we don't need to remove the team membership.
+	// If it's in the channels to join, we don't need to remove the channel membership.
 	for channelID := range proposedChannelsToLeave {
 		if _, exists := finalChannelsToJoin[channelID]; !exists {
 			finalChannelsToLeave[channelID] = true
@@ -586,7 +586,7 @@ func (k *KeycloakClient) removeUserFromTeams(teamsToLeave map[string]bool, user 
 		// Check if they are a member of the team
 		member, err := k.PluginAPI.Team.GetMember(teamID, user.Id)
 		if err != nil {
-			if strings.Contains(err.Error(), "not found") {
+			if strings.Contains(strings.ToLower(err.Error()), "not found") {
 				k.PluginAPI.Log.Debug("User has already left the team", "team_id", teamID, "user_id", user.Id)
 			} else {
 				k.PluginAPI.Log.Error("Failed to get team member",
@@ -614,7 +614,7 @@ func (k *KeycloakClient) addUserToTeams(teamsToJoin map[string]bool, user *mmMod
 		// Check if they are a member of the team
 		member, err := k.PluginAPI.Team.GetMember(teamID, user.Id)
 		if err != nil {
-			if !strings.Contains(err.Error(), "not found") {
+			if !strings.Contains(strings.ToLower(err.Error()), "not found") {
 				k.PluginAPI.Log.Error("Failed to get team member",
 					"user_id", user.Id,
 					"team_id", teamID,
@@ -640,7 +640,7 @@ func (k *KeycloakClient) removeUserFromChannels(channelsToLeave map[string]bool,
 		_, err := k.PluginAPI.Channel.GetMember(channelID, user.Id)
 		if err != nil {
 			// check if the error is because the user was not found
-			if strings.Contains(err.Error(), "not found") {
+			if strings.Contains(strings.ToLower(err.Error()), "not found") {
 				k.PluginAPI.Log.Debug("User has already left the channel", "channel_id", channelID, "user_id", user.Id)
 			} else {
 				k.PluginAPI.Log.Error("Failed to get channel member",
@@ -666,7 +666,7 @@ func (k *KeycloakClient) addUserToChannels(channelsToJoin map[string]bool, user 
 		member, err := k.PluginAPI.Channel.GetMember(channelID, user.Id)
 		if err != nil {
 			// check if the error is because the user was not found
-			if !strings.Contains(err.Error(), "not found") {
+			if !strings.Contains(strings.ToLower(err.Error()), "not found") {
 				k.PluginAPI.Log.Error("Failed to get channel member",
 					"user_id", user.Id,
 					"channel_id", channelID,

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -1721,7 +1721,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
 		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
-		api.On("LogError", "Failed to remove user from channel, unable to get channel member", "user_id", "user1", "channel_id", "channel4", "error", mock.Anything).Return()
+		api.On("LogError", "Failed to add user to channel, unable to get channel member", "user_id", "user1", "channel_id", "channel4", "error", mock.Anything).Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -380,6 +380,8 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api = &plugintest.API{}
 		client.PluginAPI = pluginapi.NewClient(api, nil)
 
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
 		// Mock GetGroups to return existing groups
 		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
 			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
@@ -402,6 +404,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
 		api.On("GetTeamMember", "team1", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 0}, nil)
 		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
 
 		// Mock channel syncables
 		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
@@ -410,9 +413,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)
-
-		// Mock logging
-		api.On("LogDebug", mock.Anything).Return()
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{
@@ -775,8 +776,10 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		// Return non Group contrained team for team2, user should not be removed from it
 		api.On("GetTeam", "team2").Return(&mmModel.Team{Id: "team2", GroupConstrained: nil}, nil)
 		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{
@@ -950,8 +953,10 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		// Mock team member creation only for AutoAdd=true teams
 		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("GetTeamMember", "team3", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 1234}, nil)
 		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to team", "team_id", "team3", "user_id", "user1").Return()
 
 		// Mock GetGroupSyncables for channels (empty)
 		api.On("GetGroupSyncables", "mm-group-1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
@@ -1026,8 +1031,10 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		// Mock channel member creation only for AutoAdd=true channels
 		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel1", "user_id", "user1").Return()
 		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{
@@ -1089,6 +1096,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeam", "team-deleted").Return(&mmModel.Team{Id: "team-deleted", GroupConstrained: mmModel.NewPointer(false)}, nil) // Non-group constrained team, don't remove them
 		api.On("GetChannelMember", "channel-deleted", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel-deleted"}, nil)
 		api.On("DeleteChannelMember", "channel-deleted", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel-deleted", "user_id", "user1").Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{
@@ -1165,8 +1173,10 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		// Mock team/channel member creation only for AutoAdd=true
 		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel1", "user_id", "user1").Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{
@@ -1258,13 +1268,17 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeamMember", "team2", "user1").Return(&mmModel.TeamMember{TeamId: "team2", DeleteAt: 0}, nil)
 		api.On("GetTeamMember", "team3", "user1").Return(&mmModel.TeamMember{TeamId: "team3", DeleteAt: 0}, nil)
 		api.On("DeleteTeamMember", "team2", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team2", "user_id", "user1").Return()
 		api.On("DeleteTeamMember", "team3", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team3", "user_id", "user1").Return()
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("GetChannelMember", "channel2", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel2"}, nil)
 		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("LogDebug", "User has already left the channel", "channel_id", "channel3", "user_id", "user1").Return()
 		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
 		api.On("DeleteChannelMember", "channel2", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
 
 		// Mock logging
 		api.On("LogDebug", mock.Anything).Return()
@@ -1329,17 +1343,23 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)                                                  // Success
+		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil) // Success
+		api.On("LogDebug", "Adding user to team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("CreateTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to team2"}) // Failure
-		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)                                                  // Success
+		api.On("LogDebug", "Adding user to team", "team_id", "team2", "user_id", "user1").Return()
+		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil) // Success
+		api.On("LogDebug", "Adding user to team", "team_id", "team3", "user_id", "user1").Return()
 
 		// Mock channel member creation with mixed results
 		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)                                                     // Success
+		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil) // Success
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel1", "user_id", "user1").Return()
 		api.On("AddChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to channel2"}) // Failure
-		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)                                                     // Success
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel2", "user_id", "user1").Return()
+		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil) // Success
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
 
 		// Mock error logging
 		api.On("LogError", "Failed to add user to team",
@@ -1407,9 +1427,12 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeamMember", "team2", "user1").Return(&mmModel.TeamMember{TeamId: "team2", DeleteAt: 0}, nil)
 		api.On("GetTeamMember", "team3", "user1").Return(&mmModel.TeamMember{TeamId: "team3", DeleteAt: 0}, nil)
 
-		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil)                                          // Success
+		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil) // Success
+		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("DeleteTeamMember", "team2", "user1", "").Return(&mmModel.AppError{Message: "removal failed"}) // Failure
-		api.On("DeleteTeamMember", "team3", "user1", "").Return(nil)                                          // Success
+		api.On("LogDebug", "Removing user from team", "team_id", "team2", "user_id", "user1").Return()
+		api.On("DeleteTeamMember", "team3", "user1", "").Return(nil) // Success
+		api.On("LogDebug", "Removing user from team", "team_id", "team3", "user_id", "user1").Return()
 
 		// Mock error logging
 		api.On("LogError", "Failed to remove user from team",
@@ -1469,9 +1492,12 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("GetChannelMember", "channel2", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel2"}, nil)
 		api.On("GetChannelMember", "channel3", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel3"}, nil)
-		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)                                          // Success
+		api.On("DeleteChannelMember", "channel1", "user1").Return(nil) // Success
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
 		api.On("DeleteChannelMember", "channel2", "user1").Return(&mmModel.AppError{Message: "removal failed"}) // Failure
-		api.On("DeleteChannelMember", "channel3", "user1").Return(nil)                                          // Success
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
+		api.On("DeleteChannelMember", "channel3", "user1").Return(nil) // Success
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel3", "user_id", "user1").Return()
 
 		// Mock error logging
 		api.On("LogError", "Failed to remove user from channel",
@@ -1677,8 +1703,11 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetTeamMember", "team5", "user1").Return(&mmModel.TeamMember{TeamId: "team5", DeleteAt: 123241}, nil) // Was previously a member
 
 		api.On("DeleteTeamMember", "team2", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team2", "user_id", "user1").Return()
 		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to team", "team_id", "team3", "user_id", "user1").Return()
 		api.On("CreateTeamMember", "team5", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to team", "team_id", "team5", "user_id", "user1").Return()
 
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("GetChannelMember", "channel2", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel2"}, nil)
@@ -1687,8 +1716,11 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("GetChannelMember", "channel5", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel5"}, nil)
 
 		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
 		api.On("DeleteChannelMember", "channel2", "user1").Return(nil)
+		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
 		api.On("LogError", "Failed to get channel member", "user_id", "user1", "channel_id", "channel4", "error", mock.Anything).Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
@@ -1710,49 +1742,6 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 			},
 		}, "groups")
 		assert.NoError(t, err)
-		api.AssertExpectations(t)
-	})
-}
-
-func TestKeycloakClient_ProcessMembershipChanges(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockGoCloak := mocks.NewMockGoCloak(ctrl)
-	mockKVStore := kvMocks.NewMockKVStore(ctrl)
-	api := &plugintest.API{}
-
-	client := &groups.KeycloakClient{
-		Client:       mockGoCloak,
-		Realm:        "test-realm",
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		Kvstore:      mockKVStore,
-		PluginAPI:    pluginapi.NewClient(api, nil),
-	}
-
-	t.Run("process membership changes", func(t *testing.T) {
-		existingGroups := []*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-			{Id: "group2", DisplayName: "Group 2"},
-		}
-
-		newGroups := map[string]*mmModel.Group{
-			"group2": {Id: "group2", DisplayName: "Group 2"},
-			"group3": {Id: "group3", DisplayName: "Group 3"},
-		}
-
-		// Mock DeleteMember for removed group
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
-
-		// Mock UpsertMember for new group
-		api.On("UpsertGroupMember", "group3", "user1").Return(nil, nil)
-
-		removed, active := client.ProcessMembershipChanges(&mmModel.User{Id: "user1"}, existingGroups, newGroups)
-
-		assert.Contains(t, removed, "group1")
-		assert.Len(t, active, 2)
-
 		api.AssertExpectations(t)
 	})
 }

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -1721,7 +1721,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
 		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
-		api.On("LogError", "Failed to get channel member", "user_id", "user1", "channel_id", "channel4", "error", mock.Anything).Return()
+		api.On("LogError", "Failed to remove user from channel, unable to get channel member", "user_id", "user1", "channel_id", "channel4", "error", mock.Anything).Return()
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
 			Assertions: []saml2Types.Assertion{

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -948,7 +948,7 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		}, nil)
 
 		// Mock team member creation only for AutoAdd=true teams
-		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "team member not found"})
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)
 		api.On("GetTeamMember", "team3", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 1234}, nil)
 		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)
@@ -1024,9 +1024,9 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		}, nil)
 
 		// Mock channel member creation only for AutoAdd=true channels
-		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)
-		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
+		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
@@ -1163,9 +1163,9 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		}, nil)
 
 		// Mock team/channel member creation only for AutoAdd=true
-		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "team member not found"})
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)
-		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)
 
 		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
@@ -1261,8 +1261,8 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.On("DeleteTeamMember", "team3", "user1", "").Return(nil)
 		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
 		api.On("GetChannelMember", "channel2", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel2"}, nil)
-		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
-		api.On("LogError", "Failed to get channel member", "user_id", "user1", "channel_id", "channel3", "error", mock.Anything).Return()
+		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "User has already left the channel", "channel_id", "channel3", "user_id", "user1").Return()
 		api.On("DeleteChannelMember", "channel1", "user1").Return(nil)
 		api.On("DeleteChannelMember", "channel2", "user1").Return(nil)
 
@@ -1326,17 +1326,17 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		}, nil)
 
 		// Mock team member creation with mixed results
-		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "team member not found"})
-		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "team member not found"})
-		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "team member not found"})
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil)                                                  // Success
 		api.On("CreateTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to team2"}) // Failure
 		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)                                                  // Success
 
 		// Mock channel member creation with mixed results
-		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
-		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
-		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "channel member not found"})
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil)                                                     // Success
 		api.On("AddChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to channel2"}) // Failure
 		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)                                                     // Success

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -1746,6 +1746,40 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 	})
 }
 
+func TestKeycloakClient_ProcessMembershipChanges(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockGoCloak := mocks.NewMockGoCloak(ctrl)
+	mockKVStore := kvMocks.NewMockKVStore(ctrl)
+	api := &plugintest.API{}
+	client := &groups.KeycloakClient{
+		Client:       mockGoCloak,
+		Realm:        "test-realm",
+		ClientID:     "test-client",
+		ClientSecret: "test-secret",
+		Kvstore:      mockKVStore,
+		PluginAPI:    pluginapi.NewClient(api, nil),
+	}
+	t.Run("process membership changes", func(t *testing.T) {
+		existingGroups := []*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+			{Id: "group2", DisplayName: "Group 2"},
+		}
+		newGroups := map[string]*mmModel.Group{
+			"group2": {Id: "group2", DisplayName: "Group 2"},
+			"group3": {Id: "group3", DisplayName: "Group 3"},
+		}
+		// Mock DeleteMember for removed group
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+		// Mock UpsertMember for new group
+		api.On("UpsertGroupMember", "group3", "user1").Return(nil, nil)
+		removed, active := client.ProcessMembershipChanges(&mmModel.User{Id: "user1"}, existingGroups, newGroups)
+		assert.Contains(t, removed, "group1")
+		assert.Len(t, active, 2)
+		api.AssertExpectations(t)
+	})
+}
+
 func TestKeycloakClient_GetExistingGroups(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
#### Summary
There are cases where a user can be part of of multiple groups that are linked to the same team or channel.

The new flow will:
1. Loop through groups to be removed from and create a map of the team/channels to remove the user from, `proposedTeamsToLeave` and `proposedChannelsToLeave`.
2. Loop through active groups and create a map of the teams/channel to join/remain in, `finalTeamsToJoin` and `finalChannelsToJoin`.
3. Loop through `proposedTeamsToLeave` and check if it's in `finalTeamsToJoin`. If it's not in `finalTeamsToJoin`, add it to `finalTeamsToLeave`.
4. Loop through `proposedChannelsToLeave` and check if it's in `finalChannelsToJoin`. If it's not in `finalChannelsToJoin`, add it to `finalChannelsToLeave`.
5. Now we have 4 distinct maps of the teams/channels the user needs to leave/join.
6. In the methods to add/remove members from teams/channel we now check the membership ourselves instead of letting the pluginapi handle it.

There is now also a check if the error was because the channel/team member wasn't found. This sets us up to add a config to fail the user login if the admin configures it.

**This PR requires regression testing.** Extra test include: Ensure there are team/channel group assignments where you are added to multiple of those groups. Ensure there are cases where you should be removed from the team with one group chnage and added to the team in another group change of the same login.
