### PR TITLE
[MM-63785] Config for failing sign in if there is a failure on during the syncing process

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -80,6 +80,13 @@
                 "type": "text",
                 "help_text": "The SAML assertion attribute that contains the user's groups.",
                 "placeholder": "Enter the groups attribute name"
+            },
+            {
+                "key": "LockOutUsersOnRemovalFailure",
+                "display_name": "Lock Out Users on Removal Failure",
+                "type": "bool",
+                "help_text": "Users will fail to sign in if there is a failure to remove them from a group, channel or team.",
+                "default": false
             }
         ]
     }

--- a/plugin.json
+++ b/plugin.json
@@ -82,8 +82,8 @@
                 "placeholder": "Enter the groups attribute name"
             },
             {
-                "key": "LockOutUsersOnRemovalFailure",
-                "display_name": "Lock Out Users on Removal Failure",
+                "key": "FailLoginOnGroupSyncError",
+                "display_name": "Fail Login on Group Sync Error",
                 "type": "bool",
                 "help_text": "Users will fail to sign in if there is a failure to remove them from a group, channel or team.",
                 "default": false

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -14,7 +14,7 @@ type Configuration struct {
 	KeycloakHost                 string `json:"keycloakhost"`
 	KeycloakGroupsAttribute      string `json:"keycloakgroupsattribute"`
 	EncryptionKey                string `json:"encryptionkey"`
-	LockOutUsersOnRemovalFailure bool   `json:"lockoutuseronremovalfailure"`
+	LockOutUsersOnRemovalFailure bool   `json:"lockoutusersonremovalfailure"`
 }
 
 // KeycloakConfig contains all Keycloak-specific configuration

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,25 +7,25 @@ import (
 // Configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration.
 type Configuration struct {
-	GroupsProvider               string `json:"groupsprovider"`
-	KeycloakRealm                string `json:"keycloakrealm"`
-	KeycloakClientID             string `json:"keycloakclientid"`
-	KeycloakClientSecret         string `json:"keycloakclientsecret"`
-	KeycloakHost                 string `json:"keycloakhost"`
-	KeycloakGroupsAttribute      string `json:"keycloakgroupsattribute"`
-	EncryptionKey                string `json:"encryptionkey"`
-	LockOutUsersOnRemovalFailure bool   `json:"lockoutusersonremovalfailure"`
+	GroupsProvider            string `json:"groupsprovider"`
+	KeycloakRealm             string `json:"keycloakrealm"`
+	KeycloakClientID          string `json:"keycloakclientid"`
+	KeycloakClientSecret      string `json:"keycloakclientsecret"`
+	KeycloakHost              string `json:"keycloakhost"`
+	KeycloakGroupsAttribute   string `json:"keycloakgroupsattribute"`
+	EncryptionKey             string `json:"encryptionkey"`
+	FailLoginOnGroupSyncError bool   `json:"failloginongroupsyncerror"`
 }
 
 // KeycloakConfig contains all Keycloak-specific configuration
 type KeycloakConfig struct {
-	Host                         string
-	Realm                        string
-	ClientID                     string
-	ClientSecret                 string
-	GroupsAttribute              string
-	EncryptionKey                string
-	LockOutUsersOnRemovalFailure bool
+	Host                      string
+	Realm                     string
+	ClientID                  string
+	ClientSecret              string
+	GroupsAttribute           string
+	EncryptionKey             string
+	FailLoginOnGroupSyncError bool
 }
 
 // ToMap converts the configuration to a map
@@ -46,13 +46,13 @@ func (c *Configuration) ToMap() (map[string]interface{}, error) {
 // GetKeycloakConfig returns all Keycloak-related configuration as a single struct
 func (c *Configuration) GetKeycloakConfig() KeycloakConfig {
 	return KeycloakConfig{
-		Host:                         c.KeycloakHost,
-		Realm:                        c.KeycloakRealm,
-		ClientID:                     c.KeycloakClientID,
-		ClientSecret:                 c.KeycloakClientSecret,
-		GroupsAttribute:              c.KeycloakGroupsAttribute,
-		EncryptionKey:                c.EncryptionKey,
-		LockOutUsersOnRemovalFailure: c.LockOutUsersOnRemovalFailure,
+		Host:                      c.KeycloakHost,
+		Realm:                     c.KeycloakRealm,
+		ClientID:                  c.KeycloakClientID,
+		ClientSecret:              c.KeycloakClientSecret,
+		GroupsAttribute:           c.KeycloakGroupsAttribute,
+		EncryptionKey:             c.EncryptionKey,
+		FailLoginOnGroupSyncError: c.FailLoginOnGroupSyncError,
 	}
 }
 
@@ -64,14 +64,14 @@ func (c *Configuration) GetGroupsProvider() string {
 // Clone creates a deep copy of the configuration.
 func (c *Configuration) Clone() *Configuration {
 	var clone = &Configuration{
-		GroupsProvider:               c.GroupsProvider,
-		KeycloakRealm:                c.KeycloakRealm,
-		KeycloakClientID:             c.KeycloakClientID,
-		KeycloakClientSecret:         c.KeycloakClientSecret,
-		KeycloakHost:                 c.KeycloakHost,
-		KeycloakGroupsAttribute:      c.KeycloakGroupsAttribute,
-		EncryptionKey:                c.EncryptionKey,
-		LockOutUsersOnRemovalFailure: c.LockOutUsersOnRemovalFailure,
+		GroupsProvider:            c.GroupsProvider,
+		KeycloakRealm:             c.KeycloakRealm,
+		KeycloakClientID:          c.KeycloakClientID,
+		KeycloakClientSecret:      c.KeycloakClientSecret,
+		KeycloakHost:              c.KeycloakHost,
+		KeycloakGroupsAttribute:   c.KeycloakGroupsAttribute,
+		EncryptionKey:             c.EncryptionKey,
+		FailLoginOnGroupSyncError: c.FailLoginOnGroupSyncError,
 	}
 	return clone
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -7,23 +7,25 @@ import (
 // Configuration captures the plugin's external configuration as exposed in the Mattermost server
 // configuration, as well as values computed from the configuration.
 type Configuration struct {
-	GroupsProvider          string `json:"groupsprovider"`
-	KeycloakRealm           string `json:"keycloakrealm"`
-	KeycloakClientID        string `json:"keycloakclientid"`
-	KeycloakClientSecret    string `json:"keycloakclientsecret"`
-	KeycloakHost            string `json:"keycloakhost"`
-	KeycloakGroupsAttribute string `json:"keycloakgroupsattribute"`
-	EncryptionKey           string `json:"encryptionkey"`
+	GroupsProvider               string `json:"groupsprovider"`
+	KeycloakRealm                string `json:"keycloakrealm"`
+	KeycloakClientID             string `json:"keycloakclientid"`
+	KeycloakClientSecret         string `json:"keycloakclientsecret"`
+	KeycloakHost                 string `json:"keycloakhost"`
+	KeycloakGroupsAttribute      string `json:"keycloakgroupsattribute"`
+	EncryptionKey                string `json:"encryptionkey"`
+	LockOutUsersOnRemovalFailure bool   `json:"lockoutuseronremovalfailure"`
 }
 
 // KeycloakConfig contains all Keycloak-specific configuration
 type KeycloakConfig struct {
-	Host            string
-	Realm           string
-	ClientID        string
-	ClientSecret    string
-	GroupsAttribute string
-	EncryptionKey   string
+	Host                         string
+	Realm                        string
+	ClientID                     string
+	ClientSecret                 string
+	GroupsAttribute              string
+	EncryptionKey                string
+	LockOutUsersOnRemovalFailure bool
 }
 
 // ToMap converts the configuration to a map
@@ -44,12 +46,13 @@ func (c *Configuration) ToMap() (map[string]interface{}, error) {
 // GetKeycloakConfig returns all Keycloak-related configuration as a single struct
 func (c *Configuration) GetKeycloakConfig() KeycloakConfig {
 	return KeycloakConfig{
-		Host:            c.KeycloakHost,
-		Realm:           c.KeycloakRealm,
-		ClientID:        c.KeycloakClientID,
-		ClientSecret:    c.KeycloakClientSecret,
-		GroupsAttribute: c.KeycloakGroupsAttribute,
-		EncryptionKey:   c.EncryptionKey,
+		Host:                         c.KeycloakHost,
+		Realm:                        c.KeycloakRealm,
+		ClientID:                     c.KeycloakClientID,
+		ClientSecret:                 c.KeycloakClientSecret,
+		GroupsAttribute:              c.KeycloakGroupsAttribute,
+		EncryptionKey:                c.EncryptionKey,
+		LockOutUsersOnRemovalFailure: c.LockOutUsersOnRemovalFailure,
 	}
 }
 
@@ -61,13 +64,14 @@ func (c *Configuration) GetGroupsProvider() string {
 // Clone creates a deep copy of the configuration.
 func (c *Configuration) Clone() *Configuration {
 	var clone = &Configuration{
-		GroupsProvider:          c.GroupsProvider,
-		KeycloakRealm:           c.KeycloakRealm,
-		KeycloakClientID:        c.KeycloakClientID,
-		KeycloakClientSecret:    c.KeycloakClientSecret,
-		KeycloakHost:            c.KeycloakHost,
-		KeycloakGroupsAttribute: c.KeycloakGroupsAttribute,
-		EncryptionKey:           c.EncryptionKey,
+		GroupsProvider:               c.GroupsProvider,
+		KeycloakRealm:                c.KeycloakRealm,
+		KeycloakClientID:             c.KeycloakClientID,
+		KeycloakClientSecret:         c.KeycloakClientSecret,
+		KeycloakHost:                 c.KeycloakHost,
+		KeycloakGroupsAttribute:      c.KeycloakGroupsAttribute,
+		EncryptionKey:                c.EncryptionKey,
+		LockOutUsersOnRemovalFailure: c.LockOutUsersOnRemovalFailure,
 	}
 	return clone
 }

--- a/server/groups/client.go
+++ b/server/groups/client.go
@@ -49,6 +49,7 @@ func NewClient(provider string, cfg *config.Configuration, kvstore kvstore.KVSto
 			keycloakConfig.ClientID,
 			keycloakConfig.ClientSecret,
 			keycloakConfig.EncryptionKey,
+			keycloakConfig.LockOutUsersOnRemovalFailure,
 			kvstore,
 			client,
 		), nil

--- a/server/groups/client.go
+++ b/server/groups/client.go
@@ -49,7 +49,7 @@ func NewClient(provider string, cfg *config.Configuration, kvstore kvstore.KVSto
 			keycloakConfig.ClientID,
 			keycloakConfig.ClientSecret,
 			keycloakConfig.EncryptionKey,
-			keycloakConfig.LockOutUsersOnRemovalFailure,
+			keycloakConfig.FailLoginOnGroupSyncError,
 			kvstore,
 			client,
 		), nil

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -619,7 +619,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 
 	// Get the syncables for new group memberships.
 	// There could be cases where the user was removed from a team or channel but is being added back to the same team or channel.
-	// We could have used groupsForAddition instead of newGroupMemberships to get the syncables but then you can end up in a situation where the user fails to be added to a group but is succesfully added to the team/channel.
+	// We could have used groupsForAddition instead of newGroupMemberships to get the syncables but then you can end up in a situation where the user fails to be added to a group but is successfully added to the team/channel.
 	// This is because the group membership can fail to be added but the syncable membership can still be added.
 	if len(newGroupMemberships) > 0 {
 		for _, groupID := range newGroupMemberships {

--- a/server/groups/keycloak.go
+++ b/server/groups/keycloak.go
@@ -458,7 +458,7 @@ func (k *KeycloakClient) HandleSAMLLogin(c *plugin.Context, user *mmModel.User, 
 			if k.FailLoginOnGroupSyncError {
 				return err
 			}
-			existingGroupMemberships = []*mmModel.Group{}
+			return nil
 		}
 
 		if len(existingGroupMemberships) > 0 {

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -1746,40 +1746,6 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 	})
 }
 
-func TestKeycloakClient_ProcessMembershipChanges(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	mockGoCloak := mocks.NewMockGoCloak(ctrl)
-	mockKVStore := kvMocks.NewMockKVStore(ctrl)
-	api := &plugintest.API{}
-	client := &groups.KeycloakClient{
-		Client:       mockGoCloak,
-		Realm:        "test-realm",
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		Kvstore:      mockKVStore,
-		PluginAPI:    pluginapi.NewClient(api, nil),
-	}
-	t.Run("process membership changes", func(t *testing.T) {
-		existingGroups := []*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-			{Id: "group2", DisplayName: "Group 2"},
-		}
-		newGroups := map[string]*mmModel.Group{
-			"group2": {Id: "group2", DisplayName: "Group 2"},
-			"group3": {Id: "group3", DisplayName: "Group 3"},
-		}
-		// Mock DeleteMember for removed group
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
-		// Mock UpsertMember for new group
-		api.On("UpsertGroupMember", "group3", "user1").Return(nil, nil)
-		removed, active := client.ProcessMembershipChanges(&mmModel.User{Id: "user1"}, existingGroups, newGroups)
-		assert.Contains(t, removed, "group1")
-		assert.Len(t, active, 2)
-		api.AssertExpectations(t)
-	})
-}
-
 func TestKeycloakClient_GetExistingGroups(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/server/groups/keycloak_test.go
+++ b/server/groups/keycloak_test.go
@@ -357,12 +357,13 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 	api := &plugintest.API{}
 
 	client := &groups.KeycloakClient{
-		Client:       mockGoCloak,
-		Realm:        "test-realm",
-		ClientID:     "test-client",
-		ClientSecret: "test-secret",
-		Kvstore:      mockKVStore,
-		PluginAPI:    pluginapi.NewClient(api, nil),
+		Client:                    mockGoCloak,
+		Realm:                     "test-realm",
+		ClientID:                  "test-client",
+		ClientSecret:              "test-secret",
+		Kvstore:                   mockKVStore,
+		PluginAPI:                 pluginapi.NewClient(api, nil),
+		FailLoginOnGroupSyncError: true,
 	}
 
 	t.Run("empty groups attribute", func(t *testing.T) {
@@ -430,89 +431,6 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 			},
 		}, "groups")
 		assert.NoError(t, err)
-		api.AssertExpectations(t)
-	})
-
-	t.Run("handle DeleteMember failure during cleanup", func(t *testing.T) {
-		// Reset the mock
-		api = &plugintest.API{}
-		client.PluginAPI = pluginapi.NewClient(api, nil)
-
-		// Mock GetGroups to return existing groups
-		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
-			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
-			FilterHasMember: "user1",
-			IncludeArchived: true,
-		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-		}, nil)
-
-		// Mock DeleteMember to fail
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, &mmModel.AppError{Message: "failed to delete member"})
-
-		// Mock logging
-		api.On("LogDebug", mock.Anything).Return()
-		api.On("LogError", "Failed to remove user from group", "user_id", "user1", "group_id", "group1", "error", mock.Anything).Return()
-
-		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
-			Assertions: []saml2Types.Assertion{
-				{
-					AttributeStatement: &saml2Types.AttributeStatement{
-						Attributes: []saml2Types.Attribute{
-							{
-								Name:   "groups",
-								Values: []saml2Types.AttributeValue{},
-							},
-						},
-					},
-				},
-			},
-		}, "groups")
-		assert.NoError(t, err) // Should not return error even if deletion fails
-		api.AssertExpectations(t)
-	})
-
-	t.Run("handle syncable processing failure during cleanup", func(t *testing.T) {
-		// Reset the mock
-		api = &plugintest.API{}
-		client.PluginAPI = pluginapi.NewClient(api, nil)
-
-		// Mock GetGroups to return existing groups
-		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
-			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
-			FilterHasMember: "user1",
-			IncludeArchived: true,
-		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-		}, nil)
-
-		// Mock successful group member deletion
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
-
-		// Mock GetGroupSyncables to fail
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return(nil, &mmModel.AppError{Message: "failed to get team syncables"})
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return(nil, &mmModel.AppError{Message: "failed to get channel syncables"})
-
-		// Mock logging
-		api.On("LogDebug", mock.Anything).Return()
-		api.On("LogError", "Failed to get teams for removal", "group_id", "group1", "error", mock.Anything).Return()
-		api.On("LogError", "Failed to get channels for removal", "group_id", "group1", "error", mock.Anything).Return()
-
-		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
-			Assertions: []saml2Types.Assertion{
-				{
-					AttributeStatement: &saml2Types.AttributeStatement{
-						Attributes: []saml2Types.Attribute{
-							{
-								Name:   "groups",
-								Values: []saml2Types.AttributeValue{},
-							},
-						},
-					},
-				},
-			},
-		}, "groups")
-		assert.NoError(t, err) // Should not return error even if syncable processing fails
 		api.AssertExpectations(t)
 	})
 
@@ -1301,231 +1219,6 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		api.AssertExpectations(t)
 	})
 
-	t.Run("partial failures in team and channel operations", func(t *testing.T) {
-		// Reset the mock
-		api = &plugintest.API{}
-		client.PluginAPI = pluginapi.NewClient(api, nil)
-
-		// Mock GetKeycloakGroupID
-		mockKVStore.EXPECT().
-			GetKeycloakGroupID("group1").
-			Return("remote-id-1", nil)
-
-		// Mock GetGroupByRemoteID
-		api.On("GetGroupByRemoteID", "remote-id-1", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
-			Id: "mm-group-1",
-		}, nil)
-
-		// Mock GetGroups for existing memberships
-		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
-			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
-			FilterHasMember: "user1",
-			IncludeArchived: true,
-		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{}, nil)
-
-		// Mock group membership operations
-		api.On("UpsertGroupMember", "mm-group-1", "user1").Return(nil, nil)
-
-		// Mock GetGroupSyncables with multiple teams and channels
-		api.On("GetGroupSyncables", "mm-group-1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
-			{GroupId: "mm-group-1", SyncableId: "team1", AutoAdd: true},
-			{GroupId: "mm-group-1", SyncableId: "team2", AutoAdd: true},
-			{GroupId: "mm-group-1", SyncableId: "team3", AutoAdd: true},
-		}, nil)
-
-		api.On("GetGroupSyncables", "mm-group-1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
-			{GroupId: "mm-group-1", SyncableId: "channel1", AutoAdd: true},
-			{GroupId: "mm-group-1", SyncableId: "channel2", AutoAdd: true},
-			{GroupId: "mm-group-1", SyncableId: "channel3", AutoAdd: true},
-		}, nil)
-
-		// Mock team member creation with mixed results
-		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("CreateTeamMember", "team1", "user1").Return(nil, nil) // Success
-		api.On("LogDebug", "Adding user to team", "team_id", "team1", "user_id", "user1").Return()
-		api.On("CreateTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to team2"}) // Failure
-		api.On("LogDebug", "Adding user to team", "team_id", "team2", "user_id", "user1").Return()
-		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil) // Success
-		api.On("LogDebug", "Adding user to team", "team_id", "team3", "user_id", "user1").Return()
-
-		// Mock channel member creation with mixed results
-		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
-		api.On("AddChannelMember", "channel1", "user1").Return(nil, nil) // Success
-		api.On("LogDebug", "Adding user to channel", "channel_id", "channel1", "user_id", "user1").Return()
-		api.On("AddChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "failed to add to channel2"}) // Failure
-		api.On("LogDebug", "Adding user to channel", "channel_id", "channel2", "user_id", "user1").Return()
-		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil) // Success
-		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
-
-		// Mock error logging
-		api.On("LogError", "Failed to add user to team",
-			"user_id", "user1",
-			"team_id", "team2",
-			"error", mock.Anything).Return()
-		api.On("LogError", "Failed to add user to channel",
-			"user_id", "user1",
-			"channel_id", "channel2",
-			"error", mock.Anything).Return()
-
-		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
-			Assertions: []saml2Types.Assertion{
-				{
-					AttributeStatement: &saml2Types.AttributeStatement{
-						Attributes: []saml2Types.Attribute{
-							{
-								Name: "groups",
-								Values: []saml2Types.AttributeValue{
-									{Value: "group1"},
-								},
-							},
-						},
-					},
-				},
-			},
-		}, "groups")
-		assert.NoError(t, err) // Overall operation should succeed despite partial failures
-		api.AssertExpectations(t)
-	})
-
-	t.Run("partial failures in team removals", func(t *testing.T) {
-		// Reset the mock
-		api = &plugintest.API{}
-		client.PluginAPI = pluginapi.NewClient(api, nil)
-
-		// Mock GetGroups to return existing memberships
-		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
-			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
-			FilterHasMember: "user1",
-			IncludeArchived: true,
-		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-		}, nil)
-
-		// Mock group membership removal
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
-
-		// Mock GetGroupSyncables with teams
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
-			{GroupId: "group1", SyncableId: "team1", AutoAdd: true},
-			{GroupId: "group1", SyncableId: "team2", AutoAdd: true},
-			{GroupId: "group1", SyncableId: "team3", AutoAdd: true},
-		}, nil)
-
-		// Mock GetGroupSyncables with channels
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
-
-		// Mock team member removal with mixed results
-		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
-		api.On("GetTeam", "team2").Return(&mmModel.Team{Id: "team2", GroupConstrained: mmModel.NewPointer(true)}, nil)
-		api.On("GetTeam", "team3").Return(&mmModel.Team{Id: "team3", GroupConstrained: mmModel.NewPointer(true)}, nil)
-
-		api.On("GetTeamMember", "team1", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 0}, nil)
-		api.On("GetTeamMember", "team2", "user1").Return(&mmModel.TeamMember{TeamId: "team2", DeleteAt: 0}, nil)
-		api.On("GetTeamMember", "team3", "user1").Return(&mmModel.TeamMember{TeamId: "team3", DeleteAt: 0}, nil)
-
-		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil) // Success
-		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
-		api.On("DeleteTeamMember", "team2", "user1", "").Return(&mmModel.AppError{Message: "removal failed"}) // Failure
-		api.On("LogDebug", "Removing user from team", "team_id", "team2", "user_id", "user1").Return()
-		api.On("DeleteTeamMember", "team3", "user1", "").Return(nil) // Success
-		api.On("LogDebug", "Removing user from team", "team_id", "team3", "user_id", "user1").Return()
-
-		// Mock error logging
-		api.On("LogError", "Failed to remove user from team",
-			"user_id", "user1",
-			"team_id", "team2",
-			"error", mock.Anything).Return()
-
-		// Mock success logging
-		api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-
-		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
-			Assertions: []saml2Types.Assertion{
-				{
-					AttributeStatement: &saml2Types.AttributeStatement{
-						Attributes: []saml2Types.Attribute{
-							{
-								Name:   "groups",
-								Values: []saml2Types.AttributeValue{},
-							},
-						},
-					},
-				},
-			},
-		}, "groups")
-		assert.NoError(t, err) // Overall operation should succeed despite partial failures
-		api.AssertExpectations(t)
-	})
-
-	t.Run("partial failures in channel removals", func(t *testing.T) {
-		// Reset the mock
-		api = &plugintest.API{}
-		client.PluginAPI = pluginapi.NewClient(api, nil)
-
-		// Mock GetGroups to return existing memberships
-		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
-			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
-			FilterHasMember: "user1",
-			IncludeArchived: true,
-		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
-			{Id: "group1", DisplayName: "Group 1"},
-		}, nil)
-
-		// Mock group membership removal
-		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
-
-		// Mock GetGroupSyncables with teams (empty)
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
-
-		// Mock GetGroupSyncables with channels
-		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
-			{GroupId: "group1", SyncableId: "channel1", AutoAdd: true},
-			{GroupId: "group1", SyncableId: "channel2", AutoAdd: true},
-			{GroupId: "group1", SyncableId: "channel3", AutoAdd: true},
-		}, nil)
-
-		// Mock channel member removal with mixed results
-		api.On("GetChannelMember", "channel1", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel1"}, nil)
-		api.On("GetChannelMember", "channel2", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel2"}, nil)
-		api.On("GetChannelMember", "channel3", "user1").Return(&mmModel.ChannelMember{ChannelId: "channel3"}, nil)
-		api.On("DeleteChannelMember", "channel1", "user1").Return(nil) // Success
-		api.On("LogDebug", "Removing user from channel", "channel_id", "channel1", "user_id", "user1").Return()
-		api.On("DeleteChannelMember", "channel2", "user1").Return(&mmModel.AppError{Message: "removal failed"}) // Failure
-		api.On("LogDebug", "Removing user from channel", "channel_id", "channel2", "user_id", "user1").Return()
-		api.On("DeleteChannelMember", "channel3", "user1").Return(nil) // Success
-		api.On("LogDebug", "Removing user from channel", "channel_id", "channel3", "user_id", "user1").Return()
-
-		// Mock error logging
-		api.On("LogError", "Failed to remove user from channel",
-			"user_id", "user1",
-			"channel_id", "channel2",
-			"error", mock.Anything).Return()
-
-		// Mock success logging
-		api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-
-		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
-			Assertions: []saml2Types.Assertion{
-				{
-					AttributeStatement: &saml2Types.AttributeStatement{
-						Attributes: []saml2Types.Attribute{
-							{
-								Name:   "groups",
-								Values: []saml2Types.AttributeValue{},
-							},
-						},
-					},
-				},
-			},
-		}, "groups")
-		assert.NoError(t, err) // Overall operation should succeed despite partial failures
-		api.AssertExpectations(t)
-	})
-
 	t.Run("removal and additions to multiple overlapping teams and channels", func(t *testing.T) {
 		// Reset the mock
 		api = &plugintest.API{}
@@ -1694,14 +1387,19 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 		}, nil)
 
 		// Mock team/channel member removals
+		// User is removed from team1 and re-added due to flow of removals/additions
+		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil) // Only get teams for remoals
 		api.On("GetTeam", "team2").Return(&mmModel.Team{Id: "team2", GroupConstrained: mmModel.NewPointer(true)}, nil) // Only get teams for remoals
 
+		api.On("GetTeamMember", "team1", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 0}, nil)
 		api.On("GetTeamMember", "team1", "user1").Return(&mmModel.TeamMember{TeamId: "team1", DeleteAt: 0}, nil)
 		api.On("GetTeamMember", "team2", "user1").Return(&mmModel.TeamMember{TeamId: "team2", DeleteAt: 0}, nil)
 		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
 		api.On("GetTeamMember", "team4", "user1").Return(&mmModel.TeamMember{TeamId: "team4", DeleteAt: 0}, nil)      // Already a member
 		api.On("GetTeamMember", "team5", "user1").Return(&mmModel.TeamMember{TeamId: "team5", DeleteAt: 123241}, nil) // Was previously a member
 
+		api.On("DeleteTeamMember", "team1", "user1", "").Return(nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
 		api.On("DeleteTeamMember", "team2", "user1", "").Return(nil)
 		api.On("LogDebug", "Removing user from team", "team_id", "team2", "user_id", "user1").Return()
 		api.On("CreateTeamMember", "team3", "user1").Return(nil, nil)
@@ -1734,6 +1432,1062 @@ func TestKeycloakClient_HandleSAMLLogin(t *testing.T) {
 									{Value: "group3"},
 									{Value: "group4"},
 									{Value: "group5"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+}
+
+func TestKeycloakClient_HandleSAMLLogin_FailLoginOnGroupSyncError_true(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGoCloak := mocks.NewMockGoCloak(ctrl)
+	mockKVStore := kvMocks.NewMockKVStore(ctrl)
+	api := &plugintest.API{}
+
+	client := &groups.KeycloakClient{
+		Client:                    mockGoCloak,
+		Realm:                     "test-realm",
+		ClientID:                  "test-client",
+		ClientSecret:              "test-secret",
+		Kvstore:                   mockKVStore,
+		PluginAPI:                 pluginapi.NewClient(api, nil),
+		FailLoginOnGroupSyncError: true,
+	}
+
+	t.Run("error in GetGroups", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{}, &mmModel.AppError{Message: "failed to get groups"})
+
+		api.On("LogError", "Failed to get existing group memberships", "user_id", "user1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in addSyncableTeamsForRemoval", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group teams"})
+		api.On("LogError", "Failed to get group teams for removal", "group_id", "group1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in addSyncableChannelsForRemoval", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "channel1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group channels"})
+		api.On("LogError", "Failed to get group channels for removal", "group_id", "group1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error skipped in addSyncableTeamsForAddition and addSyncableChannelsForAddition", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group1").
+			Return("group1", nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group1", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group1",
+		}, nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group teams"})
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group channels"})
+
+		api.On("LogError", "Failed to get group teams for addition", "group_id", "group1", "error", mock.Anything).Return()
+		api.On("LogError", "Failed to get group channels for addition", "group_id", "group2", "error", mock.Anything).Return()
+
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group1"},
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("not found error skipped in GetMember when removing user from Channel", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "channel1",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "User has already left the channel", "channel_id", "channel1", "user_id", "user1").Return()
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in GetMember when removing user from Channel", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "channel1",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "failed to get channel member"})
+		api.On("LogError", "Failed to remove user from channel, unable to get channel member", "user_id", "user1", "channel_id", "channel1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in GetTeam when removing user from Team", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("GetTeam", "team1").Return(nil, &mmModel.AppError{Message: "failed to get team"})
+		api.On("LogError", "Failed to remove user from team, unable to get team", "user_id", "user1", "team_id", "team1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("not found error skipped in GetMember when removing user from Team", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "User has already left the team", "team_id", "team1", "user_id", "user1").Return()
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in GetTeamMember when removing user from Team", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "failed to get team member"})
+		api.On("LogError", "Failed to remove user from team, unable to get team member", "user_id", "user1", "team_id", "team1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in DeleteMember when removing user from Team", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
+		api.On("GetTeamMember", "team1", "user1").Return(&mmModel.TeamMember{DeleteAt: 0}, nil)
+		api.On("LogDebug", "Removing user from team", "team_id", "team1", "user_id", "user1").Return()
+		api.On("DeleteTeamMember", "team1", "user1", "").Return(&mmModel.AppError{Message: "failed to delete team member"})
+		api.On("LogError", "Failed to remove user from team", "user_id", "user1", "team_id", "team1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("error in DeleteGroupMember", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetTeam", "team1").Return(&mmModel.Team{Id: "team1", GroupConstrained: mmModel.NewPointer(true)}, nil)
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "User has already left the team", "team_id", "team1", "user_id", "user1").Return()
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, &mmModel.AppError{Message: "failed to delete group member"})
+		api.On("LogError", "Failed to remove user from group", "user_id", "user1", "group_id", "group1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.Error(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("skip error in UpsertGroupMember", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group1").
+			Return("group1", nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group1", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group1",
+		}, nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, &mmModel.AppError{Message: "failed to upsert group member"})
+		api.On("LogError", "Failed to add user to group", "user_id", "user1", "group_id", "group2", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group1"},
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("not found error in addUserToTeams still tries to add team member and skips over other errors", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group1").
+			Return("group1", nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group1", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group1",
+		}, nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group2",
+				SyncableId: "team2",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		api.On("GetTeamMember", "team1", "user1").Return(nil, &mmModel.AppError{Message: "an error occurred"})
+		api.On("LogError", "Failed to add user to team, unable to get team member", "user_id", "user1", "team_id", "team1", "error", mock.Anything).Return()
+		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "Adding user to team", "team_id", "team2", "user_id", "user1").Return()
+		api.On("CreateTeamMember", "team2", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group1"},
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("not found error in addUserToChannels still tries to add channel member and skips over other errors", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group1").
+			Return("group1", nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group1", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group1",
+		}, nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "channel1",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group2",
+				SyncableId: "channel2",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "an error occurred"})
+		api.On("LogError", "Failed to add user to channel, unable to get channel member", "user_id", "user1", "channel_id", "channel1", "error", mock.Anything).Return()
+		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel2", "user_id", "user1").Return()
+		api.On("AddChannelMember", "channel2", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group1"},
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+}
+
+func TestKeycloakClient_HandleSAMLLogin_FailLoginOnGroupSyncError_false(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockGoCloak := mocks.NewMockGoCloak(ctrl)
+	mockKVStore := kvMocks.NewMockKVStore(ctrl)
+	api := &plugintest.API{}
+
+	client := &groups.KeycloakClient{
+		Client:                    mockGoCloak,
+		Realm:                     "test-realm",
+		ClientID:                  "test-client",
+		ClientSecret:              "test-secret",
+		Kvstore:                   mockKVStore,
+		PluginAPI:                 pluginapi.NewClient(api, nil),
+		FailLoginOnGroupSyncError: false,
+	}
+
+	t.Run("skip errors in GetGroups", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		api.On("LogDebug", "No groups found in SAML assertion").Return()
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{}, &mmModel.AppError{Message: "failed to get groups"})
+
+		api.On("LogError", "Failed to get existing group memberships", "user_id", "user1", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name:   "groups",
+								Values: []saml2Types.AttributeValue{},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("skip errors when fetching syncables", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group teams"})
+		api.On("LogError", "Failed to get group teams for removal", "group_id", "group1", "error", mock.Anything).Return()
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group channels"})
+		api.On("LogError", "Failed to get group channels for removal", "group_id", "group1", "error", mock.Anything).Return()
+
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group teams"})
+		api.On("LogError", "Failed to get group teams for addition", "group_id", "group2", "error", mock.Anything).Return()
+
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, &mmModel.AppError{Message: "failed to get group channels"})
+		api.On("LogError", "Failed to get group channels for addition", "group_id", "group2", "error", mock.Anything).Return()
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("skip errors when syncing channel memberships", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "channel1",
+				AutoAdd:    true,
+			},
+			{
+				GroupId:    "group1",
+				SyncableId: "channel2",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group2",
+				SyncableId: "channel3",
+				AutoAdd:    true,
+			},
+		}, nil)
+
+		api.On("GetChannelMember", "channel1", "user1").Return(nil, &mmModel.AppError{Message: "failed to get channel member"})
+		api.On("LogError", "Failed to remove user from channel, unable to get channel member", "user_id", "user1", "channel_id", "channel1", "error", mock.Anything).Return()
+		api.On("GetChannelMember", "channel2", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "User has already left the channel", "channel_id", "channel2", "user_id", "user1").Return()
+		api.On("GetChannelMember", "channel3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "Adding user to channel", "channel_id", "channel3", "user_id", "user1").Return()
+		api.On("AddChannelMember", "channel3", "user1").Return(nil, nil)
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("skip errors when syncing group memberships", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, &mmModel.AppError{Message: "failed to delete group member"})
+		api.On("LogError", "Failed to remove user from group", "user_id", "user1", "group_id", "group1", "error", mock.Anything).Return()
+
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, &mmModel.AppError{Message: "failed to upsert group member"})
+		api.On("LogError", "Failed to add user to group", "user_id", "user1", "group_id", "group2", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group2"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, "groups")
+		assert.NoError(t, err)
+		api.AssertExpectations(t)
+	})
+
+	t.Run("skip errors when syncing team memberships", func(t *testing.T) {
+		// Reset the mock
+		api = &plugintest.API{}
+		client.PluginAPI = pluginapi.NewClient(api, nil)
+
+		// Mock GetGroups to return existing groups
+		api.On("GetGroups", 0, 100, mmModel.GroupSearchOpts{
+			Source:          mmModel.GroupSourcePluginPrefix + "keycloak",
+			FilterHasMember: "user1",
+			IncludeArchived: true,
+		}, (*mmModel.ViewUsersRestrictions)(nil)).Return([]*mmModel.Group{
+			{Id: "group1", DisplayName: "Group 1"},
+		}, nil)
+
+		mockKVStore.EXPECT().
+			GetKeycloakGroupID("group2").
+			Return("group2", nil)
+
+		api.On("GetGroupByRemoteID", "group2", mmModel.GroupSourcePluginPrefix+"keycloak").Return(&mmModel.Group{
+			Id: "group2",
+		}, nil)
+
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group1",
+				SyncableId: "team1",
+				AutoAdd:    true,
+			},
+			{
+				GroupId:    "group1",
+				SyncableId: "team2",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group1", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("DeleteGroupMember", "group1", "user1").Return(nil, nil)
+		api.On("UpsertGroupMember", "group2", "user1").Return(nil, nil)
+
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeTeam).Return([]*mmModel.GroupSyncable{
+			{
+				GroupId:    "group2",
+				SyncableId: "team3",
+				AutoAdd:    true,
+			},
+		}, nil)
+		api.On("GetGroupSyncables", "group2", mmModel.GroupSyncableTypeChannel).Return([]*mmModel.GroupSyncable{}, nil)
+
+		api.On("GetTeam", "team1").Return(nil, &mmModel.AppError{Message: "failed to get team"})
+		api.On("LogError", "Failed to remove user from team, unable to get team", "user_id", "user1", "team_id", "team1", "error", mock.Anything).Return()
+
+		api.On("GetTeam", "team2").Return(&mmModel.Team{Id: "team2", GroupConstrained: mmModel.NewPointer(true)}, nil)
+		api.On("GetTeamMember", "team2", "user1").Return(nil, &mmModel.AppError{Message: "failed to get team member"})
+		api.On("LogError", "Failed to remove user from team, unable to get team member", "user_id", "user1", "team_id", "team2", "error", mock.Anything).Return()
+
+		api.On("GetTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "not found"})
+		api.On("LogDebug", "Adding user to team", "team_id", "team3", "user_id", "user1").Return()
+		api.On("CreateTeamMember", "team3", "user1").Return(nil, &mmModel.AppError{Message: "failed to add user to team"})
+		api.On("LogError", "Failed to add user to team", "user_id", "user1", "team_id", "team3", "error", mock.Anything).Return()
+
+		err := client.HandleSAMLLogin(nil, &mmModel.User{Id: "user1"}, &saml2.AssertionInfo{
+			Assertions: []saml2Types.Assertion{
+				{
+					AttributeStatement: &saml2Types.AttributeStatement{
+						Attributes: []saml2Types.Attribute{
+							{
+								Name: "groups",
+								Values: []saml2Types.AttributeValue{
+									{Value: "group2"},
 								},
 							},
 						},


### PR DESCRIPTION
#### Summary
This merges into https://github.com/mattermost/mattermost-plugin-identity-groups-sync/pull/17.

Added a new config, `FailLoginOnGroupSyncError`, in order to lock users out if there is some failure on groups, channel or team **removals**. I decided to only fail sign ins when there is an error **removing** someone from somewhere they should no longer be. We are logging and skipping over errors where we fail to add a user to something because I didn't want to lock a user out of Mattermost due to them being unable to access something they are allowed to access. These are the steps where we fail a sign in for a user:

1. When k.FailLoginOnGroupSyncError is true and there's a failure to get existing group memberships for the user.
2. When k.FailLoginOnGroupSyncError is true and there's a failure to add syncable teams for removal.
3. When k.FailLoginOnGroupSyncError is true and there's a failure to add syncable channels for removal.
4. When k.FailLoginOnGroupSyncError is true and there's an error removing the user from channels (via k.removeUserFromChannels)
5. When k.FailLoginOnGroupSyncError is true and there's an error removing the user from teams (via k.removeUserFromTeams)
6. When k.FailLoginOnGroupSyncError is true and there's an error removing the user from groups (via k.RemoveUserFromGroups)

I re-organized the order of removals/additions to be much more fault tolerant. It now does it in this order:
1. Sort groups into `groupsForRemoval`, `groupsForAddition`, `groupsForRetention`.
2. Get teams and channels the user needs to be removed from using `groupsForRemoval`.
3. Get teams and channels the user needs to stay in using `groupsForRetention`.
4. If a user is staying in a team/channel that they are also being removed from, delete the entry from the removals list.
5. Remove channel memberships.
6. Remove team memberships.
7. Remove from groups.
8. Add to groups.
9. Get teams and channels the user needs to be added to based off the successful additions in step 8.
10. Add to teams
11. Add to channels

Doing stuff in this order means if there is a failure at any point in the process the user will not end up in some half baked state where they are still part of a channel or team that they should not be part of on the next login.

If it fails halfway through team or channel membership removals, we still have the old group memberships so on next login we will still remove the user from any teams/channels and that group. 

The only way I can see this going wrong is if this is run while someone is in the middle of a login flow https://github.com/mattermost/mattermost-plugin-identity-groups-sync/pull/18. This is an extreme edge case though and we could optionally block logins while that job is running but we would need to know how long that job is taking to run for them.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-63785

